### PR TITLE
Feat/direct subscriber

### DIFF
--- a/src/solace_plug/exceptions.py
+++ b/src/solace_plug/exceptions.py
@@ -5,10 +5,12 @@ class SolaceError(Exception):
 class SolaceConnectionError(SolaceError):
     """Raised when connection to Solace fails."""
 
-
 class PublishError(SolaceError):
     """Raised when a publish operation times out."""
 
+
+class SubscribeError(SolaceError):
+    """Raised when a subscribe operation times out."""
 
 class CircuitBreakerError(SolaceError):
     """Raised when the circuit breaker is open and blocks operations."""

--- a/src/solace_plug/schemas/base.py
+++ b/src/solace_plug/schemas/base.py
@@ -68,13 +68,11 @@ class IncomingMessage(BaseModel):
     Provides:
       - `topic`: topic the message was published to
       - `message_id`: unique message ID if set by publisher
-      - `headers`: low-level broker metadata (destination, sender_id, etc.)
       - `properties`: user-defined metadata set at publish time
       - `event`: the actual BaseEvent payload
     """
     topic: str
     message_id: str | None = None
-    headers: dict[str, t.Any] = Field(default_factory=dict)
     properties: dict[str, t.Any] = Field(default_factory=dict)
     event: BaseEvent
 

--- a/src/solace_plug/schemas/base.py
+++ b/src/solace_plug/schemas/base.py
@@ -79,7 +79,7 @@ class IncomingMessage(BaseModel):
     event: BaseEvent
 
 
-class IncomingTopicMessage(IncomingMessage):
+class IncomingDirectMessage(IncomingMessage):
     """
     Message received from a topic (direct delivery).
 
@@ -90,7 +90,7 @@ class IncomingTopicMessage(IncomingMessage):
     delivery_mode: str = "direct"
 
 
-class IncomingQueueMessage(IncomingMessage):
+class IncomingPersistentMessage(IncomingMessage):
     """
     Message received from a queue (persistent delivery).
 

--- a/src/solace_plug/subscribers/direct.py
+++ b/src/solace_plug/subscribers/direct.py
@@ -1,0 +1,104 @@
+import logging
+import json
+import typing as t
+from solace.messaging.resources.topic_subscription import TopicSubscription
+from solace.messaging.receiver.message_receiver import MessageHandler, InboundMessage
+from solace_plug.exceptions import SubscribeError
+from solace_plug.schemas.base import IncomingDirectMessage, BaseEvent
+
+log = logging.getLogger("solace_plug")
+
+
+class _MessageHandler(MessageHandler):
+    def __init__(self, callback: t.Callable[[IncomingDirectMessage], None]):
+        self._callback = callback
+
+    def on_message(self, message: InboundMessage):
+        raw = message.get_payload_as_string()
+        event = BaseEvent.model_validate_json(raw)
+
+        incoming_msg = IncomingDirectMessage(
+            topic=message.get_destination_name(),
+            message_id=message.get_application_message_id(),
+            properties=message.get_properties() or {},
+            event=event,
+        )
+        self._callback(incoming_msg)
+
+
+class DirectSubscriber:
+    """
+    Subscribes to non-persistent (direct) messages from Solace topics.
+
+    Direct messages are fire-and-forget:
+      - No persistence
+      - Only received by active subscribers
+      - Optimized for speed
+
+    Args:
+        client: A connected SolaceClient instance.
+        topics: List of topic strings to subscribe to.
+        handler: Optional custom MessageHandler to process inbound messages.
+
+    Usage:
+        def on_msg(msg: InboundMessage):
+            print("Got message:", msg.get_payload_as_string())
+
+        sub = DirectSubscriber(client, topics=["orders.created"])
+        with sub:
+            # stays active until stopped
+            while True: ...
+    """
+
+    def __init__(
+        self,
+        client,
+        topics: list[str],
+        on_message: t.Callable[[IncomingDirectMessage], None] | None = None,
+    ):
+        if not client._connected or not client._service:
+            raise SubscribeError("Solace client is not connected.")
+
+        self._client = client
+        self._service = client.get_messaging_service()
+        self._topics = topics
+        self._receiver = None
+        self._handler = _MessageHandler(on_message or self._default_message_handler)
+
+    def _default_message_handler(self, message: IncomingDirectMessage):
+        log.info(
+            "[DirectSubscriber] New message:\n%s", message.model_dump_json(indent=4)
+        )
+
+    def start(self):
+        """Start the direct subscriber and begin receiving messages."""
+        try:
+            subs = [TopicSubscription.of(t) for t in self._topics]
+            self._receiver = (
+                self._service.create_direct_message_receiver_builder()
+                .with_subscriptions(subs)
+                .build()
+            )
+            self._receiver.start()
+            self._receiver.receive_async(self._handler)
+            log.info("Direct subscriber started on topics: %s", self._topics)
+        except Exception as e:
+            raise SubscribeError(f"Failed to start direct subscriber: {e}") from e
+
+    def stop(self):
+        """Stop and clean up the subscriber."""
+        if self._receiver:
+            try:
+                self._receiver.terminate()
+                self._receiver = None
+                log.info("Direct subscriber stopped.")
+            except Exception as e:
+                raise SubscribeError(f"Failed to stop subscriber: {e}") from e
+
+    # Context manager support
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.stop()


### PR DESCRIPTION
This pull request introduces new functionality for handling incoming Solace messages and improves error handling for subscription operations. The main changes are the addition of new message schema classes, a new subscriber implementation for direct (topic-based) messages, and a new exception for subscription errors.

**Message schema enhancements:**

* Added `IncomingMessage`, `IncomingDirectMessage`, and `IncomingPersistentMessage` classes to `src/solace_plug/schemas/base.py`, providing structured models for incoming Solace messages with fields for topic, message ID, properties, event payload, and delivery mode.

**Direct subscriber implementation:**

* Introduced `DirectSubscriber` and `_MessageHandler` classes in `src/solace_plug/subscribers/direct.py` to enable subscribing to and processing non-persistent (direct) Solace topic messages, including context manager support and customizable message handling.

**Error handling improvements:**

* Added a new `SubscribeError` exception to `src/solace_plug/exceptions.py` to handle subscription-related timeouts and failures, and integrated its usage in the new direct subscriber code. [[1]](diffhunk://#diff-b1268a7133482d42d753a7b3eaf86dab1a87be1cd756635ee5b21f7ada1d3599L8-R14) [[2]](diffhunk://#diff-5bc4a45ad8e9f202b3aa0ed03d32541639ba416d51b3dd41a89a11e4c41db977R1-R104)